### PR TITLE
Update blog_post.md

### DIFF
--- a/nonblocking/blog_post.md
+++ b/nonblocking/blog_post.md
@@ -55,11 +55,11 @@ There are many different forms and implementations of non-blocking I/O. However 
 
 When using Java, the developer can rely on Java NIO. In most JVM implementations you can expect Java NIO to use those kernel functions if applicable. However there are some subtleties when it comes to the details. As the Java NIO API is generic enough to work on all operating systems, it cannot utilize some of the advanced features that individual implementations like `epoll` or `kqueue` provide. It resembles very basic poll semantics.
 
-Thus if you are looking for a little bit of extra flexibility or performance you might want to switch to native transports directly. [Netty](https://netty.io/), one of the best network application framework on the JVM, supports both Java NIO transports as well as [native libraries](https://netty.io/wiki/native-transports.html) for Linux and Mac OS X.
+Thus if you are looking for a little bit of extra flexibility or performance you might want to switch to native transports directly. [Netty](https://netty.io/), one of the best network application frameworks on the JVM, supports both Java NIO transports and [native libraries](https://netty.io/wiki/native-transports.html) for Linux and Mac OS X.
 
-Of course most of the time you are not going to work with Java NIO or Netty directly but use some web application framework. Some frameworks will allow you to configure your network layer to some extend. In [Vert.x](https://vertx.io/), for example, you can choose whether you want to use native transports if applicable and it offers
+Of course most of the time you are not going to work with Java NIO or Netty directly but use some web application framework. Some frameworks will allow you to configure your network layer to some extent. In [Vert.x](https://vertx.io/), for example, you can choose whether you want to use native transports if applicable and it offers
 
-- [`EpollTransport`](https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/net/impl/transport/EpollTransport.java) based on Netties [`EpollEventLoopGroup`](https://netty.io/4.1/api/io/netty/channel/epoll/EpollEventLoopGroup.html),
+- [`EpollTransport`](https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/net/impl/transport/EpollTransport.java) based on Netty's [`EpollEventLoopGroup`](https://netty.io/4.1/api/io/netty/channel/epoll/EpollEventLoopGroup.html),
 - [`KQueueTransport`](https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/net/impl/transport/KQueueTransport.java) based on [`KQueueEventLoopGroup`](https://netty.io/4.1/api/io/netty/channel/kqueue/KQueueEventLoopGroup.html), and
 - [`Transport`](https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/net/impl/transport/Transport.java) based on [`NioEventLoopGroup`](https://netty.io/4.1/api/io/netty/channel/nio/NioEventLoopGroup.html).
 
@@ -69,7 +69,7 @@ The term non-blocking is used in many different ways and contexts. In this post 
 
 Take JDBC as an example. JDBC is blocking by definition. However there is a [JDBC client](https://vertx.io/docs/vertx-jdbc-client/java/) out there which has an asynchronous API. Does it block your thread while waiting for the response of the database? No! But as I mentioned earlier, JDBC is blocking by definition so who is blocking? The trick here is simply to have a second thread pool that will take the JDBC requests and block instead of your main thread.
 
-Why is that helpful? It allows you to keep doing your main work, e.g. answering to HTTP requests. If not every requests needs a JDBC connection you can still answer those with your main thread while your thread pool is blocked. This is nice but still blocking I/O and you will run into bottlenecks as soon as your work becomes bound by the JDBC communication.
+Why is that helpful? It allows you to keep doing your main work, e.g. answering to HTTP requests. If not every request needs a JDBC connection you can still answer those with your main thread while your thread pool is blocked. This is nice but still blocking I/O and you will run into bottlenecks as soon as your work becomes bound by the JDBC communication.
 
 The field is very broad and there are many more details to explore. I believe however that with a basic understanding of blocking vs. non-blocking I/O you should be able to ask the right questions when you run into performance problems. Did you ever use native transports in your application? Did you do it because you could or because you were fighting with performance issues? Let me know in the comments!
 


### PR DESCRIPTION
* spelling errors
* grammar: 
  both X and Y 
  or 
  X as well as Y
  https://community.languagetool.org/rule/show/BOTH_AS_WELL_AS?lang=en&subId=1